### PR TITLE
Update src/pal/gtk/clipboard-gtk.cpp

### DIFF
--- a/src/pal/gtk/clipboard-gtk.cpp
+++ b/src/pal/gtk/clipboard-gtk.cpp
@@ -13,7 +13,12 @@ using namespace Moonlight;
 MoonClipboardGtk::MoonClipboardGtk (MoonWindowGtk *win, MoonClipboardType clipboardType)
 {
 	GdkWindow *window = GDK_WINDOW (win->GetPlatformWindow ());
+
+#ifdef MOONLIGHT_GTK3
+	GdkDisplay *display = gdk_window_get_display (window);
+#else
 	GdkDisplay *display = gdk_drawable_get_display (GDK_DRAWABLE (window));
+#endif
 
 	GdkAtom gdk_type;
 


### PR DESCRIPTION
In this branch Moonlight is migrated from Gtk-2 to Gtk-3.
All changes are done under a flag "MOONLIGHT_GTK3".
So to enable GTK3 with moonlight use -DMOONLIGHT_GTK3 flag during configuration.
Also GTK3 libraries and GTK3 include files Path is to be given during configuration.
Also GTK3 dependents like gdk-pixbuf atk pango glib should be included in include paths with appropriate versions.
