### PR TITLE
Update src/pal/gtk/config-dialog-gtk.h

### DIFF
--- a/src/pal/gtk/config-dialog-gtk.h
+++ b/src/pal/gtk/config-dialog-gtk.h
@@ -36,10 +36,17 @@ public:
 private:
 	void AddNotebookPage (const char *label, ConfigDialogPage *page);
 
+#ifdef MOONLIGHT_GTK3
 	static void notebook_switch_page (GtkNotebook     *notebook,
-					  GtkNotebookPage *page,
+					  GtkWidget *page,
 					  guint            page_num,
 					  MoonConfigDialogGtk *dialog);
+#else
+	static void notebook_switch_page (GtkNotebook     *notebook,
+					  GtkNotebookPage *page, 
+					  guint            page_num,
+					  MoonConfigDialogGtk *dialog);
+#endif
 
 	ArrayList* pages;
 


### PR DESCRIPTION
In this branch Moonlight is migrated from Gtk-2 to Gtk-3.
All changes are done under a flag "MOONLIGHT_GTK3".
So to enable GTK3 with moonlight use -DMOONLIGHT_GTK3 flag during configuration.
Also GTK3 libraries and GTK3 include files Path is to be given during configuration.
Also GTK3 dependents like gdk-pixbuf atk pango glib should be included in include paths with appropriate versions.
