### PR TITLE
Chrome extension: Set manifest version 2

### DIFF
--- a/plugin/install/manifest.json.in
+++ b/plugin/install/manifest.json.in
@@ -1,6 +1,7 @@
 {
   "name": "Novell Moonlight",
   "version": "@CHROME_VERSION@",
+  "manifest_version": 2,
 
   "description": "The open source implementation of Microsoft Silverlight",
 


### PR DESCRIPTION
Manifest v1 has been deprecated since Chrome 18 (March 2012).

In September 2013, all extensions/plugins without manifest v2 will stop working.
https://developer.chrome.com/extensions/manifestVersion.html

This PR consists of a single line: The addition of `"manifest_version": 2,` to the manifest file.
